### PR TITLE
fixed blacklisting of pyfa's empty slots

### DIFF
--- a/parsers/eft.go
+++ b/parsers/eft.go
@@ -59,7 +59,7 @@ func ParseEFT(input Input) (ParserResult, Input) {
 
 	// remove blacklisted lines
 	for i, line := range itemsInput {
-		_, blacklisted := eftBlacklist[line]
+		_, blacklisted := eftBlacklist[strings.ToLower(line)]
 		if blacklisted {
 			eft.lines = append(eft.lines, i)
 			delete(itemsInput, i)

--- a/parsers/eft_test.go
+++ b/parsers/eft_test.go
@@ -14,7 +14,7 @@ Warp Disruptor I
 200mm AutoCannon I, EMP S
 200mm AutoCannon I, EMP S
 [empty high slot]
-[empty high slot]
+[Empty High slot]
 Garde I x5`,
 		&EFT{
 			FittingName: "Fleet Tackle",


### PR DESCRIPTION
Pyfa uses capitalized markers for empty slots, so evepraisal just outputs it as unknown item