### PR TITLE
Embed appraisal preview into page description

### DIFF
--- a/web/resources/templates/_layout.html
+++ b/web/resources/templates/_layout.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <meta name="description" content="Price check Eve Online items from Cargo Scans, Contracts, D-Scan, EFT, Inventory, Asset listing, Loot History, PI, Survey Scanner, Killmails, Wallet TransactionsBlocks, Inventory, Assets">
+    <meta name="description" content="{{template "description" .}}">
 
     <link rel="icon" href="/static/favicon.ico">
 

--- a/web/resources/templates/about.html
+++ b/web/resources/templates/about.html
@@ -1,4 +1,5 @@
 {{define "title"}}Evepraisal - API Documentation{{end}}
+{{define "description"}}Price check Eve Online items from Cargo Scans, Contracts, D-Scan, EFT, Inventory, Asset listing, Loot History, PI, Survey Scanner, Killmails, Wallet TransactionsBlocks, Inventory, Assets{{end}}
 {{define "content"}}
 <div class="col-md">
   <h4>What is this?</h4>

--- a/web/resources/templates/api.html
+++ b/web/resources/templates/api.html
@@ -1,4 +1,5 @@
 {{define "title"}}Evepraisal - API Documentation{{end}}
+{{define "description"}}Price check Eve Online items from Cargo Scans, Contracts, D-Scan, EFT, Inventory, Asset listing, Loot History, PI, Survey Scanner, Killmails, Wallet TransactionsBlocks, Inventory, Assets{{end}}
 
 {{define "content"}}
 <style>

--- a/web/resources/templates/appraisal.html
+++ b/web/resources/templates/appraisal.html
@@ -1,4 +1,5 @@
 {{define "title"}}Evepraisal - Appraisal Result {{.Page.Appraisal.ID}} [{{.Page.Appraisal.Kind}}]{{end}}
+{{define "description"}}Price check Eve Online items from Cargo Scans, Contracts, D-Scan, EFT, Inventory, Asset listing, Loot History, PI, Survey Scanner, Killmails, Wallet TransactionsBlocks, Inventory, Assets{{end}}
 
 {{define "content"}}
 <!-- Delete Modal -->

--- a/web/resources/templates/appraisal.html
+++ b/web/resources/templates/appraisal.html
@@ -1,5 +1,5 @@
-{{define "title"}}Evepraisal - Appraisal Result {{.Page.Appraisal.ID}} [{{.Page.Appraisal.Kind}}]{{end}}
-{{define "description"}}Price check Eve Online items from Cargo Scans, Contracts, D-Scan, EFT, Inventory, Asset listing, Loot History, PI, Survey Scanner, Killmails, Wallet TransactionsBlocks, Inventory, Assets{{end}}
+{{define "title"}}Evepraisal - Appraisal {{.Page.Appraisal.ID}}: {{prettybignumber .Page.Appraisal.Totals.Buy}} Buy / {{prettybignumber .Page.Appraisal.Totals.Sell}} Sell{{end}}
+{{define "description"}}{{range $i, $item := .Page.Appraisal.Items}}{{ if (lt $i 10) }}{{$item.TypeName}} - {{comma $item.Quantity}}&#xD;&#xA;{{end}}{{end}}{{end}}
 
 {{define "content"}}
 <!-- Delete Modal -->

--- a/web/resources/templates/appraisal_debug.html
+++ b/web/resources/templates/appraisal_debug.html
@@ -1,4 +1,5 @@
 {{define "title"}}Evepraisal - Appraisal Parser Debug {{.Page.Appraisal.ID}} [{{.Page.Appraisal.Kind}}]{{end}}
+{{define "description"}}Price check Eve Online items from Cargo Scans, Contracts, D-Scan, EFT, Inventory, Asset listing, Loot History, PI, Survey Scanner, Killmails, Wallet TransactionsBlocks, Inventory, Assets{{end}}
 
 {{define "content"}}
 

--- a/web/resources/templates/error.html
+++ b/web/resources/templates/error.html
@@ -1,4 +1,5 @@
 {{define "title"}}Evepraisal - {{.Page.ErrorTitle}}{{end}}
+{{define "description"}}Price check Eve Online items from Cargo Scans, Contracts, D-Scan, EFT, Inventory, Asset listing, Loot History, PI, Survey Scanner, Killmails, Wallet TransactionsBlocks, Inventory, Assets{{end}}
 {{define "content"}}
 <div class="row">
   <div class="col-lg-4">

--- a/web/resources/templates/latest.html
+++ b/web/resources/templates/latest.html
@@ -1,4 +1,5 @@
 {{define "title"}}Evepraisal - Latest Appraisals{{end}}
+{{define "description"}}Price check Eve Online items from Cargo Scans, Contracts, D-Scan, EFT, Inventory, Asset listing, Loot History, PI, Survey Scanner, Killmails, Wallet TransactionsBlocks, Inventory, Assets{{end}}
 {{define "content"}}
 <div class="container">
   <h2>Latest Appraisals</h2>

--- a/web/resources/templates/legal.html
+++ b/web/resources/templates/legal.html
@@ -1,4 +1,5 @@
 {{define "title"}}Evepraisal - Legal{{end}}
+{{define "description"}}Price check Eve Online items from Cargo Scans, Contracts, D-Scan, EFT, Inventory, Asset listing, Loot History, PI, Survey Scanner, Killmails, Wallet TransactionsBlocks, Inventory, Assets{{end}}
 {{define "content"}}
 <div class="container">
   <div class="mt-3">

--- a/web/resources/templates/main.html
+++ b/web/resources/templates/main.html
@@ -1,4 +1,5 @@
 {{define "title"}}Evepraisal - Price check Eve Online items from Cargo Scans, Contracts, D-Scan, EFT, Inventory, Asset listing, Loot History, PI, Survey Scanner, Killmails, Wallet Transactions, Inventory, Assets{{end}}
+{{define "description"}}Price check Eve Online items from Cargo Scans, Contracts, D-Scan, EFT, Inventory, Asset listing, Loot History, PI, Survey Scanner, Killmails, Wallet TransactionsBlocks, Inventory, Assets{{end}}
 
 {{define "content"}}
 <div class="row">

--- a/web/resources/templates/new-appraisal.html
+++ b/web/resources/templates/new-appraisal.html
@@ -1,4 +1,5 @@
 {{define "title"}}Evepraisal - Create a new appraisal{{end}}
+{{define "description"}}Price check Eve Online items from Cargo Scans, Contracts, D-Scan, EFT, Inventory, Asset listing, Loot History, PI, Survey Scanner, Killmails, Wallet TransactionsBlocks, Inventory, Assets{{end}}
 
 {{define "content"}}
 <div class="row">

--- a/web/resources/templates/search.html
+++ b/web/resources/templates/search.html
@@ -1,4 +1,5 @@
 {{define "title"}}Evepraisal - Search results{{end}}
+{{define "description"}}Price check Eve Online items from Cargo Scans, Contracts, D-Scan, EFT, Inventory, Asset listing, Loot History, PI, Survey Scanner, Killmails, Wallet TransactionsBlocks, Inventory, Assets{{end}}
 {{define "content"}}
 <div class="row col-lg-12">
   {{if .Page.Results}}

--- a/web/resources/templates/user_history.html
+++ b/web/resources/templates/user_history.html
@@ -1,4 +1,5 @@
 {{define "title"}}Evepraisal - Your Appraisal History{{end}}
+{{define "description"}}Price check Eve Online items from Cargo Scans, Contracts, D-Scan, EFT, Inventory, Asset listing, Loot History, PI, Survey Scanner, Killmails, Wallet TransactionsBlocks, Inventory, Assets{{end}}
 {{define "content"}}
 <div class="container">
   <h2>Your Appraisal History</h2>

--- a/web/resources/templates/view_item.html
+++ b/web/resources/templates/view_item.html
@@ -1,4 +1,5 @@
 {{define "title"}}Evepraisal -  {{.Page.Type.Name}} pricing{{end}}
+{{define "description"}}Price check Eve Online items from Cargo Scans, Contracts, D-Scan, EFT, Inventory, Asset listing, Loot History, PI, Survey Scanner, Killmails, Wallet TransactionsBlocks, Inventory, Assets{{end}}
 {{define "content"}}
 <div class="row">
   {{template "_view_item_header.html" .}}

--- a/web/resources/templates/view_items.html
+++ b/web/resources/templates/view_items.html
@@ -1,4 +1,5 @@
 {{define "title"}}Evepraisal - View Items{{end}}
+{{define "description"}}Price check Eve Online items from Cargo Scans, Contracts, D-Scan, EFT, Inventory, Asset listing, Loot History, PI, Survey Scanner, Killmails, Wallet TransactionsBlocks, Inventory, Assets{{end}}
 {{define "content"}}
 <div class="row col-lg-12">
   {{if .Page.Items}}


### PR DESCRIPTION
How evepraisal looks when posted in Discord:

![image](https://user-images.githubusercontent.com/294293/85964780-1163d680-b9bb-11ea-968d-897c3508807c.png)

How Janice looks:

![image](https://user-images.githubusercontent.com/294293/85964799-217bb600-b9bb-11ea-88ec-ea3431f3c68e.png)


With these changes evepraisal should look similar.