### PR TITLE
Set concurrency to 1

### DIFF
--- a/evepraisal/app.go
+++ b/evepraisal/app.go
@@ -61,7 +61,8 @@ func appMain() {
 
 	httpClient := pester.New()
 	httpClient.Transport = httpcache.NewTransport(httpCache)
-	httpClient.Concurrency = 4
+	// Concurrency should be 1, otherwise this can flood the market endpoint if errors are returned
+	httpClient.Concurrency = 1
 	httpClient.Timeout = 30 * time.Second
 	httpClient.Backoff = pester.ExponentialJitterBackoff
 	httpClient.MaxRetries = 10


### PR DESCRIPTION
Concurrency in pester [1] means multiple of the same request get sent at once -- this means the worst case for requests sent to CCP is `(number of retries * concurrency) * number of requests to fetch the market`.

This commit reduces concurrency number since the number of evepraisal instances that have been recently spun up are creating undue load on the market endpoints.

1: https://github.com/sethgrid/pester/blob/v1.2.0/pester.go#L317